### PR TITLE
feat: clean-up code Vastly improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# lovense-forza
-Forza Telemetry to Control Lovense Toys - Pick between RPM, Speed, Surface Rumble, Power, Torque &amp; Accel/Brake force
+# lovense-forza #
+
+Forza Telemetry to Control Lovense Toys
+
+## Running and Stopping ##
+
+`npm start`
+
+Triggers that start function in `package.json` which simply runs node on `index.js`
+
+`npm stop`
+
+## Telemetry to choose from ##
+
+Telemetry to pick between:
+
+* `rpm`            _- RPM from the Engine **(Best all around experience)**_
+* `speed`          _- Current Speed, slow but fun_
+* `rumble-average` _- Surface Rumble **(Average)**_
+* `power`          _- Not quite sure, seems to be a similar thing to RPM._
+* `torque`         _- Torque of the Vehicle_
+* `accel`          _- How hard are you pushing down on the **Accelerate** Pedal_
+* `brake`          _- How hard are you pushing down on the **Brake** Pedal_
+
+> Enter the required setting on `index.js` line **22** `var vibrationFrom = 'rpm';`
+
+## Where to get toy Data ##
+
+Enable Lovense and connect it to a device `pc, android, ios` then visit the API pagethat is now available on your lan that will return a `json` document by clicking [api/lan/getToys](https://api.lovense.com/api/lan/getToys)
+
+You are looking for the
+
+* **platform** - _pc, android, ios_
+* **domain** - _The domain Lovense is on_ e.g `192-168-178-16.lovense.club`
+* **port** - _Will proably be `30010`_
+* **toyID** - _this can be found in the `toys` section, `"status": 1` means the currently active toy (_if one is connected_) if you have two or more (_including generations_) of the same device, the are likely to show up with the same name (_e.g Domi and Domi 2 both listed as domi_) but have different `hVersions`. If you've given them nicknames that's even easier_

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,13 @@
+version: "0.2"
+ignorePaths:
+  - pnpm-lock.yaml
+  - package-lock.json
+dictionaryDefinitions: []
+dictionaries: []
+words:
+  - Accel
+  - domi
+  - Forza
+  - Lovense
+ignoreWords: []
+import: []

--- a/index.js
+++ b/index.js
@@ -1,171 +1,127 @@
 const Forza = require('forza.js');
+const nodeFetch = import('node-fetch');
 const forza = new Forza.default();
 
-const fetch = (...args) =>
-  import("node-fetch").then(({ default: fetch }) => fetch(...args));
+const fetch = (...args) => nodeFetch.then(({ default: fetch }) => fetch(...args));
 
 // Go to https://api.lovense.com/api/lan/getToys
 // And Grab a few fields
-var toy = 'TOY_ID';           // Find the ToyId (random sort of Characters to Vibrate) 
-var platform = "android";     // What Device you are using. PC / Android / iOS
-var domain = "192-168-1-98.lovense.club"; // Domain from Lovense
-var port = "30010";           // httpsPort 
+const toyID = 'F96B83E9AFF8'; // Find the ToyId (random sort of Characters to Vibrate)
+const platform = 'pc'; // What Device you are using. PC / Android / iOS
+const domain = '192-168-178-16.lovense.club'; // Domain from Lovense
+const port = '30010'; // httpsPort
 
 // Select what it will react to
-// rpm            - RPM from the Engine        (Best all around experience)
+// rpm            - RPM from the Engine (Best all around experience)
 // rumble-average - Surface Rumble (Average)
 // speed          - Speed, slow but fun
 // power          - Not quite sure, seems to be a similar thing to rpm.
 // torque         - Torque of the Vehicle
 // brake          - How hard are you pushing down on the Brake Pedal
 // accel          - How hard are you pushing down on the Accel Pedal
-var vibrationFrom = 'speed';
-var maxVibration = 20;      // Max Power of 1-20 (Use 20 if ya wanna go wild)
+const vibrationFrom = 'rpm';
+const maxVibration = 15; // Max Power of 1-20 (Use 20 if ya wanna go wild)
 
-(async function () {
-    await forza.loadGames();
-    forza.startAllGameSockets();
+function getProp(myData) {
+  const out = [];
+  for (const key in myData)
+    if (myData.hasOwnProperty(key)) out.push(key + '=' + encodeURIComponent(myData[key]));
+  return out.join('&');
+}
 
-    var processData = function(data) {
-      // Do something with data
+function lovenseUrl(endpoint, values) {
+  if (endpoint.indexOf('A') === 0 && platform == 'pc') endpoint = endpoint.substring(1); // Removes the A for PC specific.
 
-      /**
-       * 0-1 = 0% - 100%
-       */
-      var vibration = 0;
-      if (data.isRaceOn === 0) {
-      }
-      else {
-        switch (vibrationFrom) {
-          case 'rpm':
-            vibration = (data.currentEngineRpm - data.engineIdleRpm)
-                        /
-                        (data.engineMaxRpm - data.engineIdleRpm);
-            break;
+  console.log(
+    `https://${domain}:${port}/${endpoint}` +
+      (Object.keys(values).length > 0 ? `?${getProp(values)}` : '')
+  );
 
-          case 'rumble-average':
-            vibration = (
-              ((
-                data.surfaceRumbleFrontLeft + data.surfaceRumbleFrontRight +
-                data.surfaceRumbleRearLeft + data.surfaceRumbleRearRight
-              )
-              / 4)
-              * 1.666
-              // Seems to max at 6, so we're scaling it up to 10.
-            );
-            break;
-
-            // One wheel is always max?
-          // case 'rumble-max':
-          //   vibration = (
-          //     Math.max(
-          //       data.surfaceRumbleFrontLeft, data.surfaceRumbleFrontRight,
-          //       data.surfaceRumbleRearLeft, data.surfaceRumbleRearRight
-          //     )
-          //     * 1.666
-          //   );
-          //   break;
-
-          case 'speed':
-            vibration = data.speed / 100;
-            break;
-
-          case 'power':
-            vibration = Math.abs(data.power) / 1000000;
-            break;
-
-          case 'torque':
-            vibration = Math.abs(data.torque) / 1000;
-            break;
-
-          case 'brake':
-            vibration = data.brake / 255;
-            break;
-
-          case 'accel':
-            vibration = data.accel / 255;
-            break;
-        }
-
-        // console.log(vibrationFrom, vibration.toFixed(2));
-
-        var vibrationInt = Math.round(vibration * maxVibration);
-        if (vibrationInt > maxVibration) {
-          vibrationInt = maxVibration;
-        }
-      }
-
-      sendVibration(vibrationInt);
-    }
-
-    forza.on('telemetry', throttle(
-      processData,
-      100
-    ));
-
-
-})()
+  return (
+    `https://${domain}:${port}/${endpoint}` +
+    (Object.keys(values).length > 0 ? `?${getProp(values)}` : '')
+  );
+}
 
 // Throttling Function
 const throttle = (func, limit) => {
   let inThrottle;
-  return function() {
+  return function () {
     const args = arguments;
     const context = this;
     if (!inThrottle) {
       func.apply(context, args);
       inThrottle = true;
-      setTimeout(() => inThrottle = false, limit);
+      setTimeout(() => (inThrottle = false), limit);
     }
-  }
-}
+  };
+};
 
-var lastVibration = 0;
-const sendVibration = function(vibration) {
+let lastVibration = 0;
+const sendVibration = function (vibration) {
   if (vibration !== lastVibration) {
     lastVibration = vibration;
-
-    var power = vibration;
-    if (!power) { power = 0; }
-
-    var params = {
-      sec: 0,
-      v: power
-    }
-    if (toy !== 'ALL') {
-      params.t = toy;
-    }
-    console.log("Sending Vibration", vibration);
-    fetch(lovenseUrl("AVibrate", params))
-    .then(async res =>
-      console.log("Successfully sent vibration", vibration)
+    const power = vibration || 0;
+    const params = { sec: 0, v: power };
+    if (toyID !== 'ALL') params.t = toyID;
+    console.log('Sending Vibration', vibration);
+    fetch(lovenseUrl('AVibrate', params)).then(async (res) =>
+      console.log('Successfully sent vibration', vibration)
     );
   }
-}
+};
 
-function lovenseUrl(endpoint, values) {
-  if (endpoint.indexOf("A") === 0 && platform == "pc") {
-    endpoint = endpoint.substring(1); // Removes the A for PC specific.
-  }
+(async function () {
+  await forza.loadGames();
+  forza.startAllGameSockets();
 
-  console.log(
-    `https://${domain}:${port}/${endpoint}` +
-    (Object.keys(values).length > 0 ? `?${getProp(values)}` : "")
-  );
+  const processData = function (data) {
+    // Do something with data
 
-
-  return (
-    `https://${domain}:${port}/${endpoint}` +
-    (Object.keys(values).length > 0 ? `?${getProp(values)}` : "")
-  );
-
-  function getProp(myData) {
-    var out = [];
-    for (var key in myData) {
-      if (myData.hasOwnProperty(key)) {
-        out.push(key + "=" + encodeURIComponent(myData[key]));
+    /**
+     * Vibration Percentage expressed as number between `0-1`
+     * @type {number}
+     * @example
+     * var vibration = 0.5; // 50%
+     */
+    let vibration = 0.1;
+    if (data.isRaceOn !== 0) {
+      switch (vibrationFrom) {
+        case 'rpm':
+          vibration =
+            (data.currentEngineRpm - data.engineIdleRpm) / (data.engineMaxRpm - data.engineIdleRpm);
+          break;
+        case 'rumble-average':
+          vibration =
+            ((data.surfaceRumbleFrontLeft +
+              data.surfaceRumbleFrontRight +
+              data.surfaceRumbleRearLeft +
+              data.surfaceRumbleRearRight) /
+              4) *
+            1.666;
+          // Seems to max at 6, so we're scaling it up to 10.
+          break;
+        case 'speed':
+          vibration = data.speed / 100;
+          break;
+        case 'power':
+          vibration = Math.abs(data.power) / 1000000;
+          break;
+        case 'torque':
+          vibration = Math.abs(data.torque) / 1000;
+          break;
+        case 'brake':
+          vibration = data.brake / 255;
+          break;
+        case 'accel':
+          vibration = data.accel / 255;
+          break;
       }
+
+      let vibrationInt = Math.round(vibration * maxVibration);
+      if (vibrationInt > maxVibration) vibrationInt = maxVibration;
+      sendVibration(vibrationInt);
+      forza.on('telemetry', throttle(processData, 100));
     }
-    return out.join("&");
-  }
-}
+  };
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lovense-forza",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lovense-forza",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "forza.js": "github:MatthewCash/forza.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "lovense-forza",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vibrate toys as you do specific actions in Forza",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
+    "stop": "exit node",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,181 @@
+lockfileVersion: 5.4
+
+specifiers:
+  forza.js: github:MatthewCash/forza.js
+  node-fetch: ^3.2.6
+
+dependencies:
+  forza.js: github.com/MatthewCash/forza.js/d76303416841f16716f460132190957d78b6a9bb
+  node-fetch: 3.2.6
+
+packages:
+
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: false
+
+  /@jridgewell/resolve-uri/3.0.7:
+    resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
+  /@jridgewell/sourcemap-codec/1.4.13:
+    resolution: {integrity: sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==}
+    dev: false
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: false
+
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: false
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: false
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: false
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: false
+
+  /@types/node/16.11.41:
+    resolution: {integrity: sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==}
+    dev: false
+
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn/8.7.1:
+    resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: false
+
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
+  /data-uri-to-buffer/4.0.0:
+    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
+    engines: {node: '>= 12'}
+    dev: false
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
+
+  /fetch-blob/3.1.5:
+    resolution: {integrity: sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: false
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.1.5
+    dev: false
+
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: false
+
+  /node-domexception/1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
+  /node-fetch/3.2.6:
+    resolution: {integrity: sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.0
+      fetch-blob: 3.1.5
+      formdata-polyfill: 4.0.10
+    dev: false
+
+  /ts-node/10.8.1_zag423k5mmeq7scacelqeecc34:
+    resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 16.11.41
+      acorn: 8.7.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
+
+  /typescript/4.7.3:
+    resolution: {integrity: sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: false
+
+  /web-streams-polyfill/3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: false
+
+  github.com/MatthewCash/forza.js/d76303416841f16716f460132190957d78b6a9bb:
+    resolution: {tarball: https://codeload.github.com/MatthewCash/forza.js/tar.gz/d76303416841f16716f460132190957d78b6a9bb}
+    name: forza.js
+    version: 1.0.0
+    requiresBuild: true
+    dependencies:
+      '@types/node': 16.11.41
+      ts-node: 10.8.1_zag423k5mmeq7scacelqeecc34
+      typescript: 4.7.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+    dev: false


### PR DESCRIPTION
- Add start command to `package.json`
- Bump minor version
- Add config for `cspell` VSCode extension
- Used [`pnpm`](https://pnpm.io) install packages (because it's faster so there's now a `pnpm-lock.yaml`

**TODO** 

- `domain` is just the local ip address of the computer the app is running on with `.lovense.club` on the ends, this can be gotten automatically
- `port` will always be `30010` (unless something is already using that, so there should be a check for that  otherwise just use for that  otherwise just use the default and don't bother asking)
- `toyID` Should be able to be grabbed automatically by querying the [getToys](https://api.lovense.com/api/lan/getToys) and looking for the one that is active
  -   Either taking the first found or if there are more than one, perhaps offering a selection using the device `name`, `type`, `nickname` and `hVersion`) for the user to select
  - The vibration modes should not need to be manually entered into the JavaScript. passing them as command line params would be a huge improvement
  - Same with the `maxVibration`

**Nice to Have**

  - Eventually maybe even have a proper command line params menu, Using [`chalk`](https://npm.js/package/charlk) [`boxen`](https://npm.js/package/boxen)(?) and [`yargs`](https://npm.js/package/yargs)
  - Add a verbose mode that logs more of what is going on inside the app (has it connected should be on by default probably, but things like, Messages for successfully receipt of telemetry and sending of lovense data every minute or so (perhaps configurable),